### PR TITLE
Update link to ReflectionUtils.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ A easy api to send titles and subtitles from bukkit/spigot with reflection !
 
 <b>Installation:</b>
 
-This api is using the DarkBlade12's Reflection Util class:
-https://github.com/DarkBlade12/ParticleEffect/blob/master/src/com/darkblade12/particleeffect/ReflectionUtils.java
+This api is using the DarkBlade12's Reflection Util class: https://github.com/DarkBlade12/ParticleEffect/blob/master/src/main/java/com/darkblade12/particleeffect/ReflectionUtils.java
 
 Just add the 2 classes (TitleSender.java & ReflectionUtils.java) to your plugin.
 


### PR DESCRIPTION
This PR updates the link to ReflectionUtils.java. The package name was changed, making the URL give a 404 error.